### PR TITLE
Bug fixes

### DIFF
--- a/plpydbapi.py
+++ b/plpydbapi.py
@@ -138,6 +138,9 @@ class Cursor:
 
     _SPI_OK_UTILITY = 4
     _SPI_OK_SELECT = 5
+    _SPI_OK_INSERT_RETURNING = 11
+    _SPI_OK_DELETE_RETURNING = 12
+    _SPI_OK_UPDATE_RETURNING = 13
 
     def __init__(self):
         pass
@@ -175,7 +178,8 @@ class Cursor:
         self.description = None
         self.rowcount = -1
 
-        if res.status() == self._SPI_OK_SELECT:
+        if res.status() in [self._SPI_OK_SELECT, self._SPI_OK_INSERT_RETURNING,
+                self._SPI_OK_DELETE_RETURNING, self._SPI_OK_UPDATE_RETURNING]:
             if 'colnames' in res.__class__.__dict__:
                 # Use colnames to get the order of the variables in the query
                 self._execute_result = [tuple([row[col] for col in res.colnames()]) for row in res]

--- a/plpydbapi.py
+++ b/plpydbapi.py
@@ -122,6 +122,12 @@ class Connection:
         newcursor.connection = self
         return newcursor
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
 
 ## Cursor Objects
 
@@ -285,6 +291,12 @@ class Cursor:
 
     def __iter__(self):
         return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
 
 
 ## Type Objects and Constructors

--- a/plpydbapi.py
+++ b/plpydbapi.py
@@ -162,10 +162,17 @@ class Cursor:
         placeholders = []
         types = []
         values = []
-        for i, param in enumerate(parameters):
-            placeholders.append("$%d" % (i + 1))
-            types.append(self.py_param_to_pg_type(param))
-            values.append(param)
+        i = 0
+        for param in parameters:
+            if param is None:
+                # Directly put "None" as "NULL" in the sql
+                # as it's not possible to get the type
+                placeholders.append('NULL')
+            else:
+                i += 1
+                placeholders.append("$%d" % i)
+                types.append(self.py_param_to_pg_type(param))
+                values.append(param)
         query = operation % tuple(placeholders)
         try:
             plan = plpy.prepare(query, types)

--- a/plpydbapi.py
+++ b/plpydbapi.py
@@ -59,6 +59,9 @@ class Error(StandardError):
         super(Error, self).__init__()
         self.spierror = spierror
 
+    def __str__(self):
+        return str(self.spierror)
+
 
 class InterfaceError(Error):
     pass

--- a/plpydbapi.py
+++ b/plpydbapi.py
@@ -256,6 +256,9 @@ class Cursor:
             pgtype = 'int'
         elif isinstance(param, byte_types):
             pgtype = 'bytea'
+        elif isinstance(param, list):
+            # TODO Check for the usage of 'int[]' if all values are int.
+            pgtype = 'text[]'
         else:
             pgtype = 'text'
         # TODO ...

--- a/plpydbapi.py
+++ b/plpydbapi.py
@@ -176,7 +176,11 @@ class Cursor:
         self.rowcount = -1
 
         if res.status() == self._SPI_OK_SELECT:
-            self._execute_result = [tuple([row[col] for col in row]) for row in res]
+            if 'colnames' in res.__class__.__dict__:
+                # Use colnames to get the order of the variables in the query
+                self._execute_result = [tuple([row[col] for col in res.colnames()]) for row in res]
+            else:
+                self._execute_result = [tuple([row[col] for col in row]) for row in res]
             self.rownumber = 0
             if 'colnames' in res.__class__.__dict__:
                 # PG 9.2+: use .colnames() and .coltypes() methods

--- a/plpydbapi.py
+++ b/plpydbapi.py
@@ -163,10 +163,7 @@ class Cursor:
             placeholders.append("$%d" % (i + 1))
             types.append(self.py_param_to_pg_type(param))
             values.append(param)
-        if len(placeholders) == 1:
-            query = operation % placeholders[0]
-        else:
-            query = operation % placeholders
+        query = operation % tuple(placeholders)
         try:
             plan = plpy.prepare(query, types)
             res = plpy.execute(plan, values)
@@ -179,7 +176,7 @@ class Cursor:
         self.rowcount = -1
 
         if res.status() == self._SPI_OK_SELECT:
-            self._execute_result = [[row[col] for col in row] for row in res]
+            self._execute_result = [tuple([row[col] for col in row]) for row in res]
             self.rownumber = 0
             if 'colnames' in res.__class__.__dict__:
                 # PG 9.2+: use .colnames() and .coltypes() methods

--- a/test/test_plpydbapi_dbapi20.py
+++ b/test/test_plpydbapi_dbapi20.py
@@ -76,3 +76,19 @@ class test_Plpydbapi(dbapi20.DatabaseAPI20Test):
             self.fail("Driver does not support long type")
         finally:
             con.close()
+
+    def test_multiple_variables_in_query(self):
+        con = self._connect()
+        try:
+            cur = con.cursor()
+            self.executeDDL1(cur)
+            cur.execute("insert into %sbooze values (%%s)" % (
+                self.table_prefix), ['Victoria Bitter'])
+            cur.execute("insert into %sbooze values (%%s)" % (
+                self.table_prefix), ["Cooper's"])
+            cur.execute('select * from %sbooze where name = %%s or name = %%s' % (
+                self.table_prefix), ['Victoria Bitter', "Cooper's"])
+            self.assertEqual(cur.fetchall(), [('Victoria Bitter',),
+                ("Cooper's",)])
+        finally:
+            con.close()

--- a/test/test_plpydbapi_dbapi20.py
+++ b/test/test_plpydbapi_dbapi20.py
@@ -93,6 +93,19 @@ class test_Plpydbapi(dbapi20.DatabaseAPI20Test):
         finally:
             con.close()
 
+    def test_none_variables_in_query(self):
+        con = self._connect()
+        try:
+            cur = con.cursor()
+            cur.execute('create table %sbooze '
+                    '(id integer,name varchar(20))' % self.table_prefix)
+            cur.execute("insert into %sbooze values (%%s,'Victoria Bitter')" % (
+                self.table_prefix), [None])
+            cur.execute('select * from %sbooze' % self.table_prefix)
+            self.assertEqual(cur.fetchone(), (None, 'Victoria Bitter'))
+        finally:
+            con.close()
+
     @unittest.skipUnless(is_pg92_or_newer, "columns may not return in the right order without .colnames")
     def test_return_multiple_columns(self):
         con = self._connect()

--- a/test/test_plpydbapi_dbapi20.py
+++ b/test/test_plpydbapi_dbapi20.py
@@ -92,3 +92,17 @@ class test_Plpydbapi(dbapi20.DatabaseAPI20Test):
                 ("Cooper's",)])
         finally:
             con.close()
+
+    @unittest.skipUnless(is_pg92_or_newer, "columns may not return in the right order without .colnames")
+    def test_return_multiple_columns(self):
+        con = self._connect()
+        try:
+            cur = con.cursor()
+            cur.execute('create table %sbooze '
+                    '(id integer,name varchar(20),abv integer)' % self.table_prefix)
+            cur.execute("insert into %sbooze values (1,'Victoria Bitter', 5)" % (
+                self.table_prefix))
+            cur.execute('select * from %sbooze' % self.table_prefix)
+            self.assertEqual(cur.fetchone(), (1, 'Victoria Bitter', 5,))
+        finally:
+            con.close()

--- a/test/test_plpydbapi_dbapi20.py
+++ b/test/test_plpydbapi_dbapi20.py
@@ -106,3 +106,43 @@ class test_Plpydbapi(dbapi20.DatabaseAPI20Test):
             self.assertEqual(cur.fetchone(), (1, 'Victoria Bitter', 5,))
         finally:
             con.close()
+
+    def test_return_values_for_inserts(self):
+        con = self._connect()
+        try:
+            cur = con.cursor()
+            cur.execute('create table %sbooze '
+                    '(id integer,name varchar(20),abv integer)' % self.table_prefix)
+            cur.execute("insert into %sbooze values (1,'Victoria Bitter', 5) returning id" % (
+                self.table_prefix))
+            self.assertEqual(cur.fetchone()[0], 1)
+        finally:
+            con.close()
+
+    def test_return_values_for_updates(self):
+        con = self._connect()
+        try:
+            cur = con.cursor()
+            cur.execute('create table %sbooze '
+                    '(id integer,name varchar(20),abv integer)' % self.table_prefix)
+            cur.execute("insert into %sbooze values (1,'Victoria Bitter', 5)" % (
+                self.table_prefix))
+            cur.execute('update %sbooze set id = 2 where id = 1 returning name' % (
+                self.table_prefix))
+            self.assertEqual(cur.fetchone()[0], 'Victoria Bitter')
+        finally:
+            con.close()
+
+    def test_return_values_for_deletes(self):
+        con = self._connect()
+        try:
+            cur = con.cursor()
+            cur.execute('create table %sbooze '
+                    '(id integer,name varchar(20),abv integer)' % self.table_prefix)
+            cur.execute("insert into %sbooze values (1,'Victoria Bitter', 5)" % (
+                self.table_prefix))
+            cur.execute('delete from %sbooze where id = 1 returning name' % (
+                self.table_prefix))
+            self.assertEqual(cur.fetchone()[0], 'Victoria Bitter')
+        finally:
+            con.close()

--- a/test/test_plpydbapi_dbapi20.py
+++ b/test/test_plpydbapi_dbapi20.py
@@ -159,3 +159,13 @@ class test_Plpydbapi(dbapi20.DatabaseAPI20Test):
             self.assertEqual(cur.fetchone()[0], 'Victoria Bitter')
         finally:
             con.close()
+
+    def test_with(self):
+        with self._connect() as con:
+            with con.cursor() as cur:
+                self.executeDDL1(cur)
+                cur.execute("insert into %sbooze values ('Victoria Bitter')" % (
+                    self.table_prefix))
+                cur.execute('select * from %sbooze' % self.table_prefix)
+                self.assertEqual(cur.fetchall(), [('Victoria Bitter',)])
+        self.assertRaises(self.driver.Error, con.commit)


### PR DESCRIPTION
Hi,

I'm trying to use plpydbapi in my project to avoid duplicating code, but came across a few bugs:
- when I had more than one variable in cursor.execute, then it returns a TypeError (See "Fix format string constructed for query to use tuple instead of list...")
- when there are multiple columns to return, sometimes the order is not correct.  I guess it's because plpy just returns a dict with no guaranteed order, so I used colnames to fix it (See "Use colnames to order the returned result correctly...")
- I used "insert into ... returning id" but I couldn't use cursor.fetchone() (See "Return values from non select statements too...")
- when variables are None in cursor.execute, plpydbapi tries to use "text" which may not be correct (See "Directly insert NULL into the query if a variable is None")

I know that some of the tests I added should probably be in dbapi-compliance, but the last commit in that repo was in 2009.  I don't think it's still maintained, so I added all the tests in plpydbapi.

Thanks very much,
Karen
